### PR TITLE
feat: create WithdrawalRelayer using viem wagmi

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@eth-optimism/sdk": "^0.0.0-20230711223728",
     "@rainbow-me/rainbowkit": "^2.1.2",
     "@tanstack/react-query": "^5.40.0",
+    "@wagmi/core": "^2.10.5",
     "buffer": "^6.0.3",
     "ethers": "^5.7.2",
     "mixpanel-browser": "^2.47.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.40.0
         version: 5.40.0(react@18.3.1)
+      '@wagmi/core':
+        specifier: ^2.10.5
+        version: 2.10.5(@tanstack/query-core@5.40.0)(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.4.5)(utf-8-validate@6.0.4)(viem@2.13.2(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)(zod@3.23.8))(zod@3.23.8)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,8 @@ import { ConnectButton } from '@rainbow-me/rainbowkit'
 import { useAccount } from 'wagmi'
 import { useEffect } from 'react'
 
-import { Relayer } from '@/components'
 import { useMixpanel } from '@/global-context/mixpanelContext'
+import { WithdrawalRelayer } from '@/components/WithdrawalRelayer'
 
 export function App() {
   /**
@@ -31,15 +31,10 @@ export function App() {
   return (
     <>
       <h1>Superchain L2 to L1 Message Relayer</h1>
-      <ConnectButton />
+      <ConnectButton chainStatus={'none'} />
 
-      {isConnected && (
-        <>
-          <hr />
-          <Relayer />
-          <hr />
-        </>
-      )}
+      <WithdrawalRelayer />
+
       <div style={{ marginTop: '20px' }}>
         <a
           href="https://github.com/ethereum-optimism/superchain-relayer"

--- a/src/chain-pairs/chainPairs.ts
+++ b/src/chain-pairs/chainPairs.ts
@@ -2,6 +2,7 @@ import { Chain } from 'viem'
 import { mainnet, sepolia } from 'viem/chains'
 
 export type ChainPair<TL1Chain extends Chain, TL2Chain extends Chain> = {
+  id: `chainPair-${TL1Chain['id']}-${TL2Chain['id']}`
   l1Chain: TL1Chain
   l2Chain: TL2Chain
 }
@@ -11,6 +12,7 @@ export const defineChainPair = <TL1Chain extends Chain, TL2Chain extends Chain>(
   l2Chain: TL2Chain,
 ): ChainPair<TL1Chain, TL2Chain> => {
   return {
+    id: `chainPair-${l1Chain.id}-${l2Chain.id}`,
     l1Chain,
     l2Chain,
   } as const

--- a/src/chain-pairs/supportedChainPairs.ts
+++ b/src/chain-pairs/supportedChainPairs.ts
@@ -8,8 +8,6 @@ import {
   baseSepolia,
   fraxtal,
   mainnet,
-  mode,
-  modeTestnet,
   optimism,
   optimismSepolia,
   sepolia,
@@ -17,20 +15,28 @@ import {
   zoraSepolia,
 } from 'viem/chains'
 
+export const baseChainPair = defineMainnetChainPair(base)
+export const fraxtalChainPair = defineMainnetChainPair(fraxtal)
+export const optimismChainPair = defineMainnetChainPair(optimism)
+export const zoraChainPair = defineMainnetChainPair(zora)
+
+export const baseSepoliaChainPair = defineSepoliaChainPair(baseSepolia)
+export const fraxtalSepoliaChainPair = defineSepoliaChainPair(fraxtalSepolia)
+export const optimismSepoliaChainPair = defineSepoliaChainPair(optimismSepolia)
+export const zoraSepoliaChainPair = defineSepoliaChainPair(zoraSepolia)
+
 export const supportedMainnetChainPairs = [
-  defineMainnetChainPair(base),
-  defineMainnetChainPair(fraxtal),
-  defineMainnetChainPair(mode),
-  defineMainnetChainPair(optimism),
-  defineMainnetChainPair(zora),
+  baseChainPair,
+  fraxtalChainPair,
+  optimismChainPair,
+  zoraChainPair,
 ] as const
 
 export const supportedSepoliaChainPairs = [
-  defineSepoliaChainPair(baseSepolia),
-  defineSepoliaChainPair(fraxtalSepolia),
-  defineSepoliaChainPair(modeTestnet),
-  defineSepoliaChainPair(optimismSepolia),
-  defineSepoliaChainPair(zoraSepolia),
+  baseSepoliaChainPair,
+  fraxtalSepoliaChainPair,
+  optimismSepoliaChainPair,
+  zoraSepoliaChainPair,
 ] as const
 
 export const supportedChainPairs = [
@@ -50,3 +56,10 @@ export type ChainIdsToConfigure = ChainToConfigure['id']
 export type SupportedChainPair = (typeof supportedChainPairs)[number]
 export type SupportedL2Chain = SupportedChainPair['l2Chain']
 export type SupportedL2ChainId = SupportedL2Chain['id']
+
+export const supportedChainPairByL2ChainId = supportedChainPairs.reduce<
+  Record<number, SupportedChainPair>
+>((acc, chainPair) => {
+  acc[chainPair.l2Chain.id] = chainPair
+  return acc
+}, {})

--- a/src/components/WithdrawalRelayer.tsx
+++ b/src/components/WithdrawalRelayer.tsx
@@ -1,0 +1,147 @@
+import {
+  optimismSepoliaChainPair,
+  SupportedChainPair,
+  supportedChainPairByL2ChainId,
+  supportedChainPairs,
+} from '@/chain-pairs/supportedChainPairs'
+import { useState } from 'react'
+import { Hash } from 'viem'
+import { useTransactionReceipt } from 'wagmi'
+import { extractWithdrawalMessageLogs } from 'viem/op-stack'
+import { useGetWithdrawalStatus } from '@/hooks/useGetWithdrawalStatus'
+import { ReadyToProve } from '@/components/withdrawal-status/ReadyToProve'
+import { WaitingToProve } from '@/components/withdrawal-status/WaitingToProve'
+import { ReadyToFinalize } from '@/components/withdrawal-status/ReadyToFinalize'
+import { WaitingToFinalize } from '@/components/withdrawal-status/WaitingToFinalize'
+import { Finalized } from '@/components/withdrawal-status/Finalized'
+
+const WithdrawalTransactionStatus = ({
+  transactionHash,
+  chainPair,
+}: {
+  transactionHash: Hash
+  chainPair: SupportedChainPair
+}) => {
+  const { data: transactionReceipt, isLoading: isTransactionReceiptLoading } =
+    useTransactionReceipt({
+      hash: transactionHash,
+      chainId: chainPair.l2Chain.id,
+    })
+
+  const logs = transactionReceipt
+    ? extractWithdrawalMessageLogs(transactionReceipt)
+    : []
+
+  const { data: withdrawalStatus, isLoading: isWithdrawalStatusLoading } =
+    useGetWithdrawalStatus({
+      transactionReceipt,
+      chainPair: chainPair,
+    })
+
+  if (isTransactionReceiptLoading) {
+    return <div>Loading transaction...</div>
+  }
+
+  if (!transactionReceipt) {
+    return <div>Transaction not found</div>
+  }
+
+  if (logs.length === 0) {
+    return <div>No withdrawal messages found in transaction</div>
+  }
+
+  if (isWithdrawalStatusLoading || !withdrawalStatus) {
+    return <div>Loading withdrawal status...</div>
+  }
+
+  if (withdrawalStatus === 'waiting-to-prove') {
+    return (
+      <WaitingToProve transactionHash={transactionHash} chainPair={chainPair} />
+    )
+  }
+  if (withdrawalStatus === 'ready-to-prove') {
+    return (
+      <div>
+        <div>Ready to prove</div>
+        <ReadyToProve transactionHash={transactionHash} chainPair={chainPair} />
+      </div>
+    )
+  }
+
+  if (withdrawalStatus === 'waiting-to-finalize') {
+    return (
+      <WaitingToFinalize
+        transactionHash={transactionHash}
+        chainPair={chainPair}
+      />
+    )
+  }
+
+  if (withdrawalStatus === 'ready-to-finalize') {
+    return (
+      <div>
+        <div>Ready to finalize</div>
+        <ReadyToFinalize
+          transactionHash={transactionHash}
+          chainPair={chainPair}
+        />
+      </div>
+    )
+  }
+
+  return <Finalized />
+}
+
+export const WithdrawalRelayer = () => {
+  const [selectedChainPair, setSelectedChainPair] =
+    useState<SupportedChainPair>(optimismSepoliaChainPair)
+  const [withdrawalTransactionHashText, setWithdrawalTransactionHashText] =
+    useState<string>('')
+
+  const [selectedTransactionHash, setSelectedTransactionHash] = useState<
+    Hash | undefined
+  >()
+
+  return (
+    <div>
+      <h2>Search for your L2 transaction to execute a manual withdrawal:</h2>
+      <div>
+        <select
+          value={selectedChainPair.l2Chain.id}
+          onChange={(e) => {
+            const chainPair =
+              supportedChainPairByL2ChainId[Number(e.target.value)]
+            if (chainPair) {
+              setSelectedChainPair(chainPair)
+            }
+          }}
+        >
+          {supportedChainPairs.map((chainPair) => (
+            <option key={chainPair.l2Chain.id} value={chainPair.l2Chain.id}>
+              {chainPair.l2Chain.name}
+            </option>
+          ))}
+        </select>
+        <input
+          placeholder="0xabcdbeef..."
+          onChange={(e) => setWithdrawalTransactionHashText(e.target.value)}
+          value={withdrawalTransactionHashText}
+        />
+        <button
+          onClick={() => {
+            setSelectedTransactionHash(withdrawalTransactionHashText as Hash)
+          }}
+        >
+          Search
+        </button>
+      </div>
+
+      {selectedTransactionHash && (
+        <WithdrawalTransactionStatus
+          transactionHash={selectedTransactionHash}
+          chainPair={selectedChainPair}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/withdrawal-status/Finalized.tsx
+++ b/src/components/withdrawal-status/Finalized.tsx
@@ -1,0 +1,3 @@
+export const Finalized = () => {
+  return <div>Finalized</div>
+}

--- a/src/components/withdrawal-status/ReadyToFinalize.tsx
+++ b/src/components/withdrawal-status/ReadyToFinalize.tsx
@@ -1,0 +1,73 @@
+import { SupportedChainPair } from '@/chain-pairs/supportedChainPairs'
+import { rainbowKitWagmiConfig } from '@/global-context/rainbowKitWagmiConfig'
+import { useWithdrawalMessage } from '@/hooks/useWithdrawalMessage'
+import { useMutation } from '@tanstack/react-query'
+import { getWalletClient, switchChain } from '@wagmi/core'
+import { Hash } from 'viem'
+import { walletActionsL1, GetWithdrawalsReturnType } from 'viem/op-stack'
+import { useTransactionReceipt } from 'wagmi'
+
+const useWriteFinalizeWithdrawal = () => {
+  return useMutation({
+    mutationFn: async ({
+      chainPair,
+      withdrawal,
+    }: {
+      chainPair: SupportedChainPair
+      withdrawal: GetWithdrawalsReturnType[number]
+    }) => {
+      if (!withdrawal) {
+        return
+      }
+
+      await switchChain(rainbowKitWagmiConfig, {
+        chainId: chainPair.l1Chain.id,
+      })
+
+      const walletClient = await getWalletClient(rainbowKitWagmiConfig, {
+        chainId: chainPair.l1Chain.id,
+      })
+
+      // @ts-ignore TODO fix types for expected chains
+      return await walletClient.extend(walletActionsL1()).finalizeWithdrawal({
+        withdrawal,
+        targetChain: chainPair.l2Chain,
+      })
+    },
+  })
+}
+
+export const ReadyToFinalize = ({
+  transactionHash,
+  chainPair,
+}: {
+  transactionHash: Hash
+  chainPair: SupportedChainPair
+}) => {
+  const { data: receipt, isLoading } = useTransactionReceipt({
+    hash: transactionHash,
+    chainId: chainPair.l2Chain.id,
+  })
+
+  const withdrawal = useWithdrawalMessage(receipt)
+
+  const { mutate, isPending, error } = useWriteFinalizeWithdrawal()
+
+  const isButtonDisabled = !withdrawal || isLoading || isPending
+
+  return (
+    <div>
+      <button
+        disabled={isButtonDisabled}
+        onClick={() => {
+          if (!withdrawal) {
+            return
+          }
+          mutate({ chainPair, withdrawal })
+        }}
+      >
+        Finalize
+      </button>
+    </div>
+  )
+}

--- a/src/components/withdrawal-status/ReadyToProve.tsx
+++ b/src/components/withdrawal-status/ReadyToProve.tsx
@@ -1,0 +1,104 @@
+import {
+  SupportedChainPair,
+  SupportedL2Chain,
+} from '@/chain-pairs/supportedChainPairs'
+import { rainbowKitWagmiConfig } from '@/global-context/rainbowKitWagmiConfig'
+import { useBuildProveWithdrawal } from '@/hooks/useBuildProveWithdrawal'
+import { useGetL2Output } from '@/hooks/useGetL2Output'
+import { useWithdrawalMessage } from '@/hooks/useWithdrawalMessage'
+import { useMutation } from '@tanstack/react-query'
+import { getWalletClient, switchChain } from '@wagmi/core'
+import { Hash } from 'viem'
+import { BuildProveWithdrawalReturnType, walletActionsL1 } from 'viem/op-stack'
+import { useTransactionReceipt } from 'wagmi'
+
+const useProveWithdrawalParams = ({
+  transactionHash,
+  chainPair,
+}: {
+  transactionHash?: Hash
+  chainPair: SupportedChainPair
+}) => {
+  const { data: receipt } = useTransactionReceipt({
+    hash: transactionHash,
+    chainId: chainPair.l2Chain.id,
+  })
+
+  const { data: l2Output } = useGetL2Output({
+    l2BlockNumber: receipt?.blockNumber,
+    chainPair,
+  })
+
+  const withdrawal = useWithdrawalMessage(receipt)
+
+  return useBuildProveWithdrawal({
+    withdrawal,
+    output: l2Output,
+    chainPair,
+  })
+}
+
+const useWriteProveWithdrawal = () => {
+  return useMutation({
+    mutationFn: async ({
+      chainPair,
+      proveWithdrawalParams,
+    }: {
+      chainPair: SupportedChainPair
+      proveWithdrawalParams: BuildProveWithdrawalReturnType<
+        undefined,
+        undefined,
+        SupportedL2Chain
+      >
+    }) => {
+      if (!proveWithdrawalParams) {
+        return
+      }
+
+      await switchChain(rainbowKitWagmiConfig, {
+        chainId: chainPair.l1Chain.id,
+      })
+
+      const walletClient = await getWalletClient(rainbowKitWagmiConfig, {
+        chainId: chainPair.l1Chain.id,
+      })
+
+      return await walletClient
+        .extend(walletActionsL1())
+        .proveWithdrawal(proveWithdrawalParams)
+    },
+  })
+}
+
+export const ReadyToProve = ({
+  transactionHash,
+  chainPair,
+}: {
+  transactionHash: Hash
+  chainPair: SupportedChainPair
+}) => {
+  const { data: proveWithdrawalParams, isLoading } = useProveWithdrawalParams({
+    transactionHash,
+    chainPair,
+  })
+
+  const { mutate, isPending, error } = useWriteProveWithdrawal()
+
+  const isButtonDisabled = !proveWithdrawalParams || isLoading || isPending
+
+  return (
+    <div>
+      <button
+        disabled={isButtonDisabled}
+        onClick={() => {
+          if (!proveWithdrawalParams) {
+            return
+          }
+          mutate({ chainPair, proveWithdrawalParams })
+        }}
+      >
+        Prove
+      </button>
+    </div>
+  )
+}

--- a/src/components/withdrawal-status/WaitingToFinalize.tsx
+++ b/src/components/withdrawal-status/WaitingToFinalize.tsx
@@ -1,0 +1,42 @@
+import { SupportedChainPair } from '@/chain-pairs/supportedChainPairs'
+import { useGetTimeToFinalize } from '@/hooks/useGetTimeToFinalize'
+import { Hash } from 'viem'
+
+const EstimatedRemainingTime = ({
+  transactionHash,
+  chainPair,
+}: {
+  transactionHash: Hash
+  chainPair: SupportedChainPair
+}) => {
+  const { data, isLoading } = useGetTimeToFinalize({
+    transactionHash,
+    chainPair,
+  })
+  if (!data || isLoading) return <div>Estimated time loading...</div>
+
+  return (
+    <div>
+      <div>Estimated remaining time</div>
+      <div>{data.seconds} seconds</div>
+    </div>
+  )
+}
+
+export const WaitingToFinalize = ({
+  transactionHash,
+  chainPair,
+}: {
+  transactionHash: Hash
+  chainPair: SupportedChainPair
+}) => {
+  return (
+    <div>
+      <div>Waiting to finalize...</div>
+      <EstimatedRemainingTime
+        transactionHash={transactionHash}
+        chainPair={chainPair}
+      />
+    </div>
+  )
+}

--- a/src/components/withdrawal-status/WaitingToProve.tsx
+++ b/src/components/withdrawal-status/WaitingToProve.tsx
@@ -1,0 +1,43 @@
+import { SupportedChainPair } from '@/chain-pairs/supportedChainPairs'
+import { useGetTimeToProve } from '@/hooks/useGetTimeToProve'
+import { Hash } from 'viem'
+
+const EstimatedRemainingTime = ({
+  transactionHash,
+  chainPair,
+}: {
+  transactionHash: Hash
+  chainPair: SupportedChainPair
+}) => {
+  const { data, isLoading } = useGetTimeToProve({
+    transactionHash,
+    chainPair,
+  })
+
+  if (!data || isLoading) return <div>Estimated time loading...</div>
+
+  return (
+    <div>
+      <div>Estimated remaining time</div>
+      <div>{data.seconds} seconds</div>
+    </div>
+  )
+}
+
+export const WaitingToProve = ({
+  transactionHash,
+  chainPair,
+}: {
+  transactionHash: Hash
+  chainPair: SupportedChainPair
+}) => {
+  return (
+    <div>
+      <div>Waiting to prove...</div>
+      <EstimatedRemainingTime
+        transactionHash={transactionHash}
+        chainPair={chainPair}
+      />
+    </div>
+  )
+}

--- a/src/global-context/rainbowKitWagmiConfig.ts
+++ b/src/global-context/rainbowKitWagmiConfig.ts
@@ -8,9 +8,7 @@ import {
   sepolia,
   fraxtal,
   base,
-  mode,
   baseSepolia,
-  modeTestnet,
   zoraSepolia,
   optimismSepolia,
 } from 'wagmi/chains'
@@ -27,7 +25,6 @@ const transports = {
   [mainnet.id]: http(),
   [base.id]: http(),
   [fraxtal.id]: http(),
-  [mode.id]: http(),
   [optimism.id]: http(),
   [zora.id]: http(),
 
@@ -35,7 +32,6 @@ const transports = {
   [sepolia.id]: http(),
   [baseSepolia.id]: http(),
   [fraxtalSepolia.id]: http(),
-  [modeTestnet.id]: http(),
   [optimismSepolia.id]: http(),
   [zoraSepolia.id]: http(),
 } as const satisfies Record<ChainIdsToConfigure, Transport>

--- a/src/hooks/useBuildProveWithdrawal.ts
+++ b/src/hooks/useBuildProveWithdrawal.ts
@@ -1,0 +1,43 @@
+import {
+  SupportedChainPair,
+  SupportedL2Chain,
+} from '@/chain-pairs/supportedChainPairs'
+import { useQuery } from '@tanstack/react-query'
+import {
+  GetL2OutputReturnType,
+  GetWithdrawalsReturnType,
+  publicActionsL2,
+} from 'viem/op-stack'
+import { usePublicClient } from 'wagmi'
+
+export const useBuildProveWithdrawal = ({
+  withdrawal,
+  output,
+  chainPair,
+}: {
+  withdrawal?: GetWithdrawalsReturnType[number]
+  output?: GetL2OutputReturnType
+  chainPair: SupportedChainPair
+}) => {
+  const publicClientL2 = usePublicClient({ chainId: chainPair.l2Chain.id })
+  return useQuery({
+    enabled: !!publicClientL2 && !!withdrawal && !!output,
+    queryKey: [
+      'build-prove-withdrawal',
+      chainPair.id,
+      withdrawal?.withdrawalHash,
+      output?.l2BlockNumber.toString(),
+    ],
+    queryFn: async () => {
+      if (!publicClientL2 || !withdrawal || !output) {
+        return
+      }
+      return await publicClientL2
+        .extend(publicActionsL2())
+        .buildProveWithdrawal<SupportedL2Chain>({
+          output,
+          withdrawal,
+        })
+    },
+  })
+}

--- a/src/hooks/useGetL2Output.ts
+++ b/src/hooks/useGetL2Output.ts
@@ -1,0 +1,27 @@
+import { SupportedChainPair } from '@/chain-pairs/supportedChainPairs'
+import { useQuery } from '@tanstack/react-query'
+import { publicActionsL1 } from 'viem/op-stack'
+import { usePublicClient } from 'wagmi'
+
+export const useGetL2Output = ({
+  l2BlockNumber,
+  chainPair,
+}: {
+  l2BlockNumber?: bigint
+  chainPair: SupportedChainPair
+}) => {
+  const publicClientL1 = usePublicClient({ chainId: chainPair.l1Chain.id })
+  return useQuery({
+    enabled: !!publicClientL1 && !!l2BlockNumber,
+    queryKey: ['get-l2-output', chainPair.id, l2BlockNumber?.toString()],
+    queryFn: async () => {
+      if (!publicClientL1 || l2BlockNumber === undefined) {
+        return
+      }
+      return await publicClientL1.extend(publicActionsL1()).getL2Output({
+        l2BlockNumber,
+        targetChain: chainPair.l2Chain,
+      })
+    },
+  })
+}

--- a/src/hooks/useGetTimeToFinalize.ts
+++ b/src/hooks/useGetTimeToFinalize.ts
@@ -1,0 +1,38 @@
+import { SupportedChainPair } from '@/chain-pairs/supportedChainPairs'
+import { useWithdrawalMessage } from '@/hooks/useWithdrawalMessage'
+import { useQuery } from '@tanstack/react-query'
+import { Hash } from 'viem'
+import { publicActionsL1 } from 'viem/op-stack'
+import { useTransactionReceipt } from 'wagmi'
+import { usePublicClient } from 'wagmi'
+
+export const useGetTimeToFinalize = ({
+  transactionHash,
+  chainPair,
+}: {
+  transactionHash: Hash
+  chainPair: SupportedChainPair
+}) => {
+  const { data: receipt } = useTransactionReceipt({
+    hash: transactionHash,
+    chainId: chainPair.l2Chain.id,
+  })
+
+  const l1PublicClient = usePublicClient({ chainId: chainPair.l1Chain.id })
+
+  const withdrawal = useWithdrawalMessage(receipt)
+
+  return useQuery({
+    enabled: !!receipt && !!l1PublicClient,
+    queryKey: ['get-time-to-finalize', chainPair.id, transactionHash],
+    queryFn: async () => {
+      if (!receipt || !l1PublicClient || !withdrawal) return
+
+      return await l1PublicClient.extend(publicActionsL1()).getTimeToFinalize({
+        withdrawalHash: withdrawal.withdrawalHash,
+        targetChain: chainPair.l2Chain,
+      })
+    },
+    refetchInterval: 6 * 1000,
+  })
+}

--- a/src/hooks/useGetTimeToProve.ts
+++ b/src/hooks/useGetTimeToProve.ts
@@ -1,0 +1,35 @@
+import { SupportedChainPair } from '@/chain-pairs/supportedChainPairs'
+import { useQuery } from '@tanstack/react-query'
+import { Hash } from 'viem'
+import { publicActionsL1 } from 'viem/op-stack'
+import { useTransactionReceipt } from 'wagmi'
+import { usePublicClient } from 'wagmi'
+
+export const useGetTimeToProve = ({
+  transactionHash,
+  chainPair,
+}: {
+  transactionHash: Hash
+  chainPair: SupportedChainPair
+}) => {
+  const { data: receipt } = useTransactionReceipt({
+    hash: transactionHash,
+    chainId: chainPair.l2Chain.id,
+  })
+
+  const l1PublicClient = usePublicClient({ chainId: chainPair.l1Chain.id })
+
+  return useQuery({
+    enabled: !!receipt && !!l1PublicClient,
+    queryKey: ['get-time-to-prove', chainPair.id, transactionHash],
+    queryFn: async () => {
+      if (!receipt || !l1PublicClient) return
+
+      return await l1PublicClient.extend(publicActionsL1()).getTimeToProve({
+        receipt,
+        targetChain: chainPair.l2Chain,
+      })
+    },
+    refetchInterval: 6 * 1000,
+  })
+}

--- a/src/hooks/useGetWithdrawalStatus.ts
+++ b/src/hooks/useGetWithdrawalStatus.ts
@@ -1,0 +1,40 @@
+import { SupportedChainPair } from '@/chain-pairs/supportedChainPairs'
+import { useQuery } from '@tanstack/react-query'
+import { TransactionReceipt } from 'viem'
+import { usePublicClient } from 'wagmi'
+import { publicActionsL1 } from 'viem/op-stack'
+
+export const useGetWithdrawalStatus = ({
+  transactionReceipt,
+  chainPair,
+}: {
+  transactionReceipt?: TransactionReceipt
+  chainPair: SupportedChainPair
+}) => {
+  const l1PublicClient = usePublicClient({ chainId: chainPair.l1Chain.id })
+
+  return useQuery({
+    enabled: !!transactionReceipt && l1PublicClient !== undefined,
+    queryKey: [
+      'get-withdrawal-status',
+      chainPair.id,
+      transactionReceipt?.transactionHash,
+    ],
+    queryFn: async () => {
+      if (!transactionReceipt || !l1PublicClient) {
+        return
+      }
+
+      const withdrawalStatus = await l1PublicClient
+        .extend(publicActionsL1())
+        .getWithdrawalStatus({
+          receipt: transactionReceipt,
+          targetChain: chainPair.l2Chain,
+        })
+
+      return withdrawalStatus
+    },
+
+    refetchInterval: 6 * 1000,
+  })
+}

--- a/src/hooks/useInvalidateGetWithdrawalStatus.ts
+++ b/src/hooks/useInvalidateGetWithdrawalStatus.ts
@@ -1,0 +1,12 @@
+import { useQueryClient } from '@tanstack/react-query'
+
+export const useInvalidateGetWithdrawalStatus = () => {
+  const queryClient = useQueryClient()
+  return {
+    invalidate: (chainPairId: string, transactionHash: string) => {
+      queryClient.invalidateQueries({
+        queryKey: ['get-withdrawal-status', chainPairId, transactionHash],
+      })
+    },
+  }
+}

--- a/src/hooks/useWithdrawalMessage.ts
+++ b/src/hooks/useWithdrawalMessage.ts
@@ -1,0 +1,6 @@
+import { TransactionReceipt } from 'viem'
+import { getWithdrawals } from 'viem/op-stack'
+
+export const useWithdrawalMessage = (receipt?: TransactionReceipt) => {
+  return receipt ? getWithdrawals(receipt)[0] : undefined
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,3 @@
-@tailwind base;
+/* @tailwind base;
 @tailwind components;
-@tailwind utilities;
+@tailwind utilities; */


### PR DESCRIPTION
- create a set of hooks for the main read / write viem functions withdrawal flow
- adds components for each state of the withdrawal status ie `ready-to-prove`, `ready-to-finalize`
- very barebones UI - will update with designs once ready