### PR TITLE
temp fix: explictly use finalizeWithdrawalTransactionExternalProof entrypoint when OptimismPortal2

### DIFF
--- a/src/components/WithdrawalRelayer.tsx
+++ b/src/components/WithdrawalRelayer.tsx
@@ -57,6 +57,8 @@ const WithdrawalTransactionStatus = ({
       chainPair: chainPair,
     })
 
+  const { status, proofSubmitter } = withdrawalStatus ?? {}
+
   if (isTransactionReceiptLoading) {
     return (
       <Alert>
@@ -91,12 +93,12 @@ const WithdrawalTransactionStatus = ({
     )
   }
 
-  if (withdrawalStatus === 'waiting-to-prove') {
+  if (status === 'waiting-to-prove') {
     return (
       <WaitingToProve transactionHash={transactionHash} chainPair={chainPair} />
     )
   }
-  if (withdrawalStatus === 'ready-to-prove') {
+  if (status === 'ready-to-prove') {
     return (
       <Card>
         <CardHeader>
@@ -112,7 +114,7 @@ const WithdrawalTransactionStatus = ({
     )
   }
 
-  if (withdrawalStatus === 'waiting-to-finalize') {
+  if (status === 'waiting-to-finalize') {
     return (
       <WaitingToFinalize
         transactionHash={transactionHash}
@@ -121,7 +123,7 @@ const WithdrawalTransactionStatus = ({
     )
   }
 
-  if (withdrawalStatus === 'ready-to-finalize') {
+  if (status === 'ready-to-finalize') {
     return (
       <Card>
         <CardHeader>
@@ -131,6 +133,7 @@ const WithdrawalTransactionStatus = ({
           <ReadyToFinalize
             transactionHash={transactionHash}
             chainPair={chainPair}
+            proofSubmitter={proofSubmitter}
           />
         </CardContent>
       </Card>

--- a/src/components/withdrawal-status/ReadyToFinalize.tsx
+++ b/src/components/withdrawal-status/ReadyToFinalize.tsx
@@ -1,48 +1,18 @@
 import { SupportedChainPair } from '@/chain-pairs/supportedChainPairs'
-import { rainbowKitWagmiConfig } from '@/global-context/rainbowKitWagmiConfig'
 import { useWithdrawalMessage } from '@/hooks/useWithdrawalMessage'
-import { useMutation } from '@tanstack/react-query'
-import { getWalletClient, switchChain } from '@wagmi/core'
-import { Hash } from 'viem'
-import { walletActionsL1, GetWithdrawalsReturnType } from 'viem/op-stack'
+import { Address, Hash } from 'viem'
 import { useTransactionReceipt } from 'wagmi'
 
-const useWriteFinalizeWithdrawal = () => {
-  return useMutation({
-    mutationFn: async ({
-      chainPair,
-      withdrawal,
-    }: {
-      chainPair: SupportedChainPair
-      withdrawal: GetWithdrawalsReturnType[number]
-    }) => {
-      if (!withdrawal) {
-        return
-      }
-
-      await switchChain(rainbowKitWagmiConfig, {
-        chainId: chainPair.l1Chain.id,
-      })
-
-      const walletClient = await getWalletClient(rainbowKitWagmiConfig, {
-        chainId: chainPair.l1Chain.id,
-      })
-
-      // @ts-ignore TODO fix types for expected chains
-      return await walletClient.extend(walletActionsL1()).finalizeWithdrawal({
-        withdrawal,
-        targetChain: chainPair.l2Chain,
-      })
-    },
-  })
-}
+import { useWriteFinalizeWithdrawal } from '@/hooks/useWriteFinalizeWithdrawal'
 
 export const ReadyToFinalize = ({
   transactionHash,
   chainPair,
+  proofSubmitter,
 }: {
   transactionHash: Hash
   chainPair: SupportedChainPair
+  proofSubmitter: Address | undefined
 }) => {
   const { data: receipt, isLoading } = useTransactionReceipt({
     hash: transactionHash,
@@ -63,7 +33,7 @@ export const ReadyToFinalize = ({
           if (!withdrawal) {
             return
           }
-          mutate({ chainPair, withdrawal })
+          mutate({ chainPair, withdrawal, proofSubmitter })
         }}
       >
         Finalize

--- a/src/hooks/useGetWithdrawalStatus.ts
+++ b/src/hooks/useGetWithdrawalStatus.ts
@@ -1,8 +1,9 @@
 import { SupportedChainPair } from '@/chain-pairs/supportedChainPairs'
 import { useQuery } from '@tanstack/react-query'
-import { TransactionReceipt } from 'viem'
 import { usePublicClient } from 'wagmi'
-import { publicActionsL1 } from 'viem/op-stack'
+import { Address, parseAbiItem, TransactionReceipt } from 'viem'
+import { readContract } from 'viem/actions'
+import { getPortalVersion, getWithdrawals, publicActionsL1 } from 'viem/op-stack'
 
 export const useGetWithdrawalStatus = ({
   transactionReceipt,
@@ -32,7 +33,57 @@ export const useGetWithdrawalStatus = ({
           targetChain: chainPair.l2Chain,
         })
 
-      return withdrawalStatus
+      // If the status is not waiting to finalize, no further action is deeded
+      if (withdrawalStatus != 'ready-to-finalize') {
+        return { status: withdrawalStatus, proofSubmitter: undefined }
+      }
+
+      // Also nothing else to do if using the legacy OptimismPortal
+      const portalAddress = chainPair.l2Chain.contracts.portal[chainPair.l1Chain.id].address
+      const portalVersion = await getPortalVersion(l1PublicClient, { chain: chainPair.l1Chain, targetChain: chainPair.l2Chain })
+      if (portalVersion.major < 3) {
+        return { status: withdrawalStatus, proofSubmitter: undefined }
+      }
+
+      const withdrawal = getWithdrawals(transactionReceipt)[0] // relayer doesn't have support for multi withdrawals
+      const numProofSubmitters = await readContract(l1PublicClient, {
+        abi: [parseAbiItem('function numProofSubmitters(bytes32) external view returns (uint256)')],
+        address: portalAddress,
+        functionName: 'numProofSubmitters',
+        args: [withdrawal.withdrawalHash],
+      }).catch(() => 1n)
+
+      // Surface the first submitter that passes checks
+
+      let proofSubmitter: Address | undefined;
+      for (let i = 0; i < numProofSubmitters; i++) {
+        const submitter = await readContract(l1PublicClient, {
+          abi: [parseAbiItem('function proofSubmitters(bytes32,uint256) external view returns (address)')],
+          address: portalAddress,
+          functionName: 'proofSubmitters',
+          args: [withdrawal.withdrawalHash, BigInt(i)],
+        }).catch(() => withdrawal.sender)
+
+        const checkedWithdrawalResult = await Promise.allSettled([readContract(l1PublicClient, {
+          abi: [parseAbiItem('function checkWithdrawal(bytes32,address) public view')],
+          address: portalAddress,
+          functionName: 'checkWithdrawal',
+          args: [withdrawal.withdrawalHash, submitter],
+        })])
+
+        if (checkedWithdrawalResult[0].status !== 'rejected') {
+          proofSubmitter = submitter
+          break
+        }
+      }
+
+      if (!proofSubmitter) {
+        // Should not reach this branch
+        console.error('No valid proof submitter found when viem returned a valid status!!!')
+        return { status: 'waiting-to-prove', proofSubmitter: undefined }
+      }
+
+      return { status: withdrawalStatus, proofSubmitter }
     },
 
     refetchInterval: 6 * 1000,

--- a/src/hooks/useWriteFinalizeWithdrawal.ts
+++ b/src/hooks/useWriteFinalizeWithdrawal.ts
@@ -1,0 +1,45 @@
+import { SupportedChainPair } from '@/chain-pairs/supportedChainPairs'
+import { rainbowKitWagmiConfig } from '@/global-context/rainbowKitWagmiConfig'
+import { useMutation } from '@tanstack/react-query'
+import { getWalletClient, switchChain } from '@wagmi/core'
+import { Address, parseAbiItem } from 'viem'
+import { walletActionsL1, GetWithdrawalsReturnType } from 'viem/op-stack'
+
+export const useWriteFinalizeWithdrawal = () => {
+    return useMutation({
+      mutationFn: async ({
+        chainPair,
+        withdrawal,
+        proofSubmitter,
+      }: {
+        chainPair: SupportedChainPair
+        withdrawal: GetWithdrawalsReturnType[number]
+        proofSubmitter: Address | undefined
+      }) => {
+        if (!withdrawal) {
+          return
+        }
+  
+        await switchChain(rainbowKitWagmiConfig, { chainId: chainPair.l1Chain.id, })
+        const walletClient = await getWalletClient(rainbowKitWagmiConfig, { chainId: chainPair.l1Chain.id, })
+
+        // Legacy OptimismPortal
+        if (!proofSubmitter) {
+            // @ts-ignore TODO fix types for expected chains
+            return await walletClient.extend(walletActionsL1()).finalizeWithdrawal({
+                withdrawal,
+                targetChain: chainPair.l2Chain,
+            })
+        }
+
+        // Use the external proof entrypoint
+        const portalAddress = chainPair.l2Chain.contracts.portal[chainPair.l1Chain.id].address
+        await walletClient.writeContract({
+            abi: [parseAbiItem('function finalizeWithdrawalTransactionExternalProof((uint256,address,address,uint256,uint256,bytes),address) external')],
+            address: portalAddress,
+            functionName: 'finalizeWithdrawalTransactionExternalProof',
+            args: [[withdrawal.nonce, withdrawal.sender, withdrawal.target, withdrawal.value, withdrawal.gasLimit, withdrawal.data], proofSubmitter],
+        })
+      },
+    })
+  }


### PR DESCRIPTION
**Description**

In the new optimism portal (>= v3) with fault proofs, the default proof submitter is the sending account when finalizing transaction. This means the same account that proved the withdrawal must be the one to finalize.

We can use `finalizeWithdrawalTransactionExternalProof` so that anyone can finalize a transaction like the legacy optimism portal that used the L2OutputOracle contract.

**Tests**

1. Run relayer

Sample OPM withdrawal with fault proofs: 0x039d2fdf3161910cb667ed599a0a899314bd5041797b6707ba312792b6d43b5c

Sample Fraxtal withdrawal legacy: 0x1b7dfe6ef960d8de0aea91b5472c88af61d3e24347f5cdef9079b1cc46c4a791


2. Ensure tx can be finalized by an arbitrary account (passing simulation will be sufficient)

**Additional context**

This is temporary since we'll create official bindings in the ecosystem repo that will automate this